### PR TITLE
Add CMD to run tinyproxy with debug logging

### DIFF
--- a/eq-tinyproxy-image/Dockerfile
+++ b/eq-tinyproxy-image/Dockerfile
@@ -7,3 +7,4 @@ COPY eq-tinyproxy-image/tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
 RUN apk update && apk add --no-cache tinyproxy=1.11.2-r0
 VOLUME /etc/tinyproxy
 EXPOSE 8888
+CMD ["tinyproxy", "-d"]


### PR DESCRIPTION
### What is the context of this PR?
The tinyproxy service needs the `tinyproxy` debug command when container starts

### How to review
Check that the tinyproxy service is running when starting a docker container