### PR TITLE
Pin Alpine version

### DIFF
--- a/eq-tinyproxy-image/Dockerfile
+++ b/eq-tinyproxy-image/Dockerfile
@@ -2,9 +2,9 @@
 # Dockerfile for tinyproxy
 #
 
-FROM alpine:3
+FROM alpine:3.20
 COPY eq-tinyproxy-image/tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
-RUN apk update && apk add --no-cache tinyproxy
+RUN apk update && apk add --no-cache tinyproxy=1.11.2-r0
 VOLUME /etc/tinyproxy
 EXPOSE 8888
 CMD ["tinyproxy", "-d"]

--- a/eq-tinyproxy-image/Dockerfile
+++ b/eq-tinyproxy-image/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM alpine:3
 COPY eq-tinyproxy-image/tinyproxy.conf /etc/tinyproxy/tinyproxy.conf
-RUN apk update && apk add --no-cache tinyproxy=1.11.2-r0
+RUN apk update && apk add --no-cache tinyproxy
 VOLUME /etc/tinyproxy
 EXPOSE 8888
 CMD ["tinyproxy", "-d"]


### PR DESCRIPTION
### What is the context of this PR?
To remove the version number from the tinyproxy command in the Dockerfile. We want to do this as every time a new version of Tinyproxy is added to the Alpine packages repo, we have to manually update the Dockerfile to use the new version, if not, an error can appear. This process can be difficult to setting up a concourse instance, thus we should unpin the version.

### How to review 
- Build the Dockerfile locally and see if any error messages appear
- May be sufficient to test building locally, but potentially create a pipeline to build the Tinyproxy image
