### PR TITLE
Add Terraform 1.9.6 install step to eq-terraform-deploy-image

### DIFF
--- a/eq-terraform-deploy-image/Dockerfile
+++ b/eq-terraform-deploy-image/Dockerfile
@@ -15,7 +15,8 @@ ENV PATH /google-cloud-sdk/bin:$PATH
 RUN apk add --no-cache python3 bash jq git curl && \
     git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
 	ln -s /root/.tfenv/bin/* /usr/local/bin && \
-	tfenv install 1.7.3
+	tfenv install 1.7.3 && \
+    tfenv install 1.9.6
 
 # Copy binaries from the builder
 COPY --from=builder google-cloud-sdk/lib /google-cloud-sdk/lib


### PR DESCRIPTION
### What is the context of this PR?
This PR is needed for all the `eq-terraform-gcp` repos we have that require the upgrade from Terraform 1.7.3 to 1.9.6.
`eq-terraform-deploy-image` is used in multiple tasks and needs to have this upgrade for tfenv so we can use the correct installed version.

### How to review
Locally `docker build` this image and check if it works after, possibly by entering the containerised image shell and checking if 1.9.6 is installed. You can also check this by using your staging `eq-terraform-gcp`'s `feature-prepop-terraform-upgrade` branch but you would need to point your staging to this docker image pushed to some bucket.
