### PR TITLE
Remove tfenv auto install versions from Dockerfile

### DIFF
--- a/eq-terraform-deploy-image/Dockerfile
+++ b/eq-terraform-deploy-image/Dockerfile
@@ -15,8 +15,7 @@ ENV PATH /google-cloud-sdk/bin:$PATH
 RUN apk add --no-cache python3 bash jq git curl && \
     git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
 	ln -s /root/.tfenv/bin/* /usr/local/bin && \
-	tfenv install 1.7.3 && \
-    tfenv install 1.9.6
+	tfenv install 1.7.3
 
 # Copy binaries from the builder
 COPY --from=builder google-cloud-sdk/lib /google-cloud-sdk/lib

--- a/eq-terraform-deploy-image/Dockerfile
+++ b/eq-terraform-deploy-image/Dockerfile
@@ -15,7 +15,8 @@ ENV PATH /google-cloud-sdk/bin:$PATH
 RUN apk add --no-cache python3 bash jq git curl && \
     git clone https://github.com/tfutils/tfenv.git ~/.tfenv && \
 	ln -s /root/.tfenv/bin/* /usr/local/bin && \
-	tfenv install 1.7.3
+	tfenv install 1.7.3 && \
+    tfenv install 1.9.6
 
 # Copy binaries from the builder
 COPY --from=builder google-cloud-sdk/lib /google-cloud-sdk/lib

--- a/eq-terraform-deploy-image/Dockerfile
+++ b/eq-terraform-deploy-image/Dockerfile
@@ -27,5 +27,10 @@ RUN gcloud config set core/disable_usage_reporting true && \
     gcloud config set component_manager/disable_update_check true && \
     gcloud config set metrics/environment github_docker_image
 
+# Sets TFENV_AUTO_INSTALL=false so that by default only versions of
+# Terraform included in this image are used i.e. other versions are not
+# downloaded and installed.
+ENV TFENV_AUTO_INSTALL=false
+
 # Set the default configuration directory
 VOLUME ["/root/.config"]


### PR DESCRIPTION
### What is the context of this PR?
By default, we want to only install versions of Terraform included in this image. Without the new env var introduced in this PR the `TFENV_AUTO_INSTALL` will be set to `true`.

### How to review
Keep only one version of Terraform installed using tfenv, build and push this docker image to Artifact Registry, use it in an environment like staging and try to make it fail when used with some branches of `terraform-gcp` repos that require different Terraform version, so it fails. Try to achieve a similar result:


