### PR TITLE
Introduce Docker build for Datastore emultor

### DIFF
--- a/eq-datastore-emulator/Dockerfile
+++ b/eq-datastore-emulator/Dockerfile
@@ -1,0 +1,9 @@
+FROM google/cloud-sdk:alpine
+RUN apk --update add openjdk21-jre
+RUN gcloud components install --quiet beta cloud-datastore-emulator
+
+VOLUME /data
+
+EXPOSE 8432
+
+CMD ["gcloud", "beta", "emulators", "datastore", "start", "--quiet", "--host-port=0.0.0.0:8432"]

--- a/eq-datastore-emulator/README.md
+++ b/eq-datastore-emulator/README.md
@@ -1,0 +1,24 @@
+# Google Cloud Datastore Emulator Image
+
+This image provides a dockerised version of the [Google Cloud Datastore Emulator](https://cloud.google.com/datastore/docs/tools/datastore-emulator). It is intended to be used as a service for development and test. It is **NOT** intended be used in formal environments.
+
+[Google Datastore](https://cloud.google.com/datastore/) is a flexible, scalable No SQL database service.
+
+### Useful commands
+
+Build a new image locally by running:
+```sh
+docker build . -t gcloud-datastore-emulator:local
+```
+Run a container by running:
+```bash
+docker run --name gcloud-datastore-emulator -p 8432:8432 -p 8989:8989 -e CLOUDSDK_CORE_PROJECT=local gcloud-datastore-emulator:local
+```
+Exec into the container by running:
+```bash
+docker exec -i -t -u root gcloud-pubsub-emulator /bin/sh
+```
+Once in the container check the gcloud components
+```bash
+gcloud components list --show-versions
+```

--- a/eq-datastore-emulator/README.md
+++ b/eq-datastore-emulator/README.md
@@ -16,7 +16,7 @@ docker run --name gcloud-datastore-emulator -p 8432:8432 -p 8989:8989 -e CLOUDSD
 ```
 Exec into the container by running:
 ```bash
-docker exec -i -t -u root gcloud-pubsub-emulator /bin/sh
+docker exec -i -t -u root gcloud-datastore-emulator /bin/sh
 ```
 Once in the container check the gcloud components
 ```bash


### PR DESCRIPTION
### What is the context of this PR?

Testing of the strategic Corporate Mac book found that the long standing third party [knarz/datastore-emulator](https://hub.docker.com/r/knarz/datastore-emulator) is [no longer maintained](https://github.com/knarz/datastore-emulator), and the image does not work with the arm64 hosted container runtime. The amd64 image cannot be emulated by the Rosetta framework.

This PR introduces a Dockerfile to create a non-productionised image to provide the more appropriate Google Cloud SDK Datastore Emulator.

### How to review

Locally build an image with this `eq-datastore-emulator` Dockerfile and update the [eq-questionnaire-runner](https://github.com/search?q=repo%3AONSdigital%2Feq-questionnaire-runner%20knarz&type=code) dependencies to use this image. Ensure automated and manual testing behaves as expected in a local environment.

### Out of scope/TODO

- introduce the image build into the [automated image build](https://github.com/ONSdigital/eq-runner-docker-images/blob/main/.github/workflows/pull_request.yml#L12) pipeline and ensure the image is pushed to GAR
- update [eq-questionnaire-runner](https://github.com/search?q=repo%3AONSdigital%2Feq-questionnaire-runner%20knarz&type=code) dependencies to use the image from GAR.
- ensure CI/CD tests pass